### PR TITLE
Fix autosync systemd unit setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -396,6 +396,18 @@ EOF
 deploy_cid_sync() {
   if [[ "$IS_PRIMARY_NODE" == "y" ]]; then
     echo "[6/6] Enabling autosync on primary node..."
+    local SERVICE_FILE="/etc/systemd/system/cid-autosync.service"
+    local TIMER_FILE="/etc/systemd/system/cid-autosync.timer"
+
+    if [[ ! -f "$SERVICE_FILE" || ! -f "$TIMER_FILE" ]]; then
+      echo "→ CID autosync unit files missing. Installing..."
+      curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/cid-autosync.service -o /tmp/cid-autosync.service
+      curl -fsSL https://raw.githubusercontent.com/compmonks/HI-pfs/main/scripts/cid-autosync.timer -o /tmp/cid-autosync.timer
+      sudo mv /tmp/cid-autosync.service "$SERVICE_FILE"
+      sudo mv /tmp/cid-autosync.timer "$TIMER_FILE"
+      sudo systemctl daemon-reload
+    fi
+
     sudo systemctl enable cid-autosync.timer
     sudo systemctl start cid-autosync.timer
   else


### PR DESCRIPTION
## Summary
- install missing cid-autosync.timer and service files if absent
- reload systemd and start the timer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4452a840832a85178ee29b58347c