### PR TITLE
Fix environment variables when running bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -227,13 +227,13 @@ done
 # 6. RUN CLOUDFLARED & SETUP.SH
 #-------------#
 log "⚙️ Running cloudflared.sh setup..."
-sudo -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/cloudflared.sh"
+sudo -E -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/cloudflared.sh"
 
 log "🧠 Starting main setup.sh for IPFS and services..."
-sudo -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/setup.sh"
+sudo -E -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/setup.sh"
 
 log "📡 Installing token-server service..."
-sudo -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/token-server.sh"
+sudo -E -H -u "$IPFS_USER" bash "$SCRIPTS_DIR/token-server.sh"
 
 #-------------#
 # 7. CREATE SYSTEMD TIMERS


### PR DESCRIPTION
## Summary
- allow environment variables to be preserved when bootstrap runs scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883323e9cb8832a952980c27ac14781