### PR TITLE
Fix auto-token watcher setup quoting

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -248,7 +248,7 @@ setup_auto_token_generator() {
 
   mkdir -p "/home/$IPFS_USER/scripts" "/home/$IPFS_USER/ipfs-admin/uploads" "$(dirname $LOG_FILE)"
 
-  cat <<EOSH | tee "$WATCH_SCRIPT" > /dev/null
+  cat <<'EOSH' | tee "$WATCH_SCRIPT" > /dev/null
 #!/bin/bash
 WATCH_DIR="$WATCH_DIR"
 LOG_FILE="$LOG_FILE"


### PR DESCRIPTION
## Summary
- prevent variable expansion when generating auto token watcher script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688337afdad8832aa91560568b37ea41